### PR TITLE
Php 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+/.phpcs-cache
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,25 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.4
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 8.0
       env:
         - DEPS=lowest
-    - php: 7.2
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: 8.0
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "ext-json": "*",
         "laminas/laminas-eventmanager": "^2.6.3 || ^3.0.1",
         "laminas/laminas-http": "^2.5.4",
@@ -37,8 +37,9 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5"
+        "laminas/laminas-coding-standard": "^2.1",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,7 +9,7 @@
 namespace Laminas\ApiTools\ApiProblem;
 
 return [
-    'service_manager' => [
+    'service_manager'       => [
         'aliases'   => [
             ApiProblemListener::class  => Listener\ApiProblemListener::class,
             RenderErrorListener::class => Listener\RenderErrorListener::class,
@@ -37,13 +37,11 @@ return [
             View\ApiProblemStrategy::class                 => Factory\ApiProblemStrategyFactory::class,
         ],
     ],
-
-    'view_manager' => [
+    'view_manager'          => [
         // Enable this in your application configuration in order to get full
         // exception stack traces in your API-Problem responses.
         'display_exceptions' => false,
     ],
-
     'api-tools-api-problem' => [
         // Accept types that should allow ApiProblem responses
         // 'accept_filters' => $stringOrArray,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,22 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>config</file>
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="LaminasApiProblem Module Tests">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="LaminasApiProblem Module Tests">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -13,6 +13,17 @@ use Laminas\ApiTools\ApiProblem\Exception\InvalidArgumentException;
 use Laminas\ApiTools\ApiProblem\Exception\ProblemExceptionInterface;
 use Throwable;
 
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function count;
+use function get_class;
+use function in_array;
+use function is_numeric;
+use function sprintf;
+use function strtolower;
+use function trim;
+
 /**
  * Object describing an API-Problem payload.
  */
@@ -21,7 +32,7 @@ class ApiProblem
     /**
      * Content type for api problem response
      */
-    const CONTENT_TYPE = 'application/problem+json';
+    public const CONTENT_TYPE = 'application/problem+json';
 
     /**
      * Additional details to include in report.
@@ -65,9 +76,9 @@ class ApiProblem
      * @var array
      */
     protected $normalizedProperties = [
-        'type' => 'type',
+        'type'   => 'type',
         'status' => 'status',
-        'title' => 'title',
+        'title'  => 'title',
         'detail' => 'detail',
     ];
 
@@ -126,8 +137,6 @@ class ApiProblem
     protected $title;
 
     /**
-     * Constructor.
-     *
      * Create an instance using the provided information. If nothing is
      * provided for the type field, the class default will be used;
      * if the status matches any known, the title field will be selected
@@ -154,7 +163,8 @@ class ApiProblem
         }
 
         // Ensure a valid HTTP status
-        if (! is_numeric($status)
+        if (
+            ! is_numeric($status)
             || ($status < 100)
             || ($status > 599)
         ) {
@@ -163,7 +173,7 @@ class ApiProblem
 
         $this->status = $status;
         $this->detail = $detail;
-        $this->title = $title;
+        $this->title  = $title;
 
         if (null !== $type) {
             $this->type = $type;
@@ -210,8 +220,8 @@ class ApiProblem
     public function toArray()
     {
         $problem = [
-            'type' => $this->type,
-            'title' => $this->getTitle(),
+            'type'   => $this->type,
+            'title'  => $this->getTitle(),
             'status' => $this->getStatus(),
             'detail' => $this->getDetail(),
         ];
@@ -286,8 +296,9 @@ class ApiProblem
             return $this->title;
         }
 
-        if (null === $this->title
-            && $this->type == 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html'
+        if (
+            null === $this->title
+            && $this->type === 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html'
             && array_key_exists($this->getStatus(), $this->problemStatusTitles)
         ) {
             return $this->problemStatusTitles[$this->status];
@@ -318,18 +329,18 @@ class ApiProblem
             return $e->getMessage();
         }
 
-        $message = trim($e->getMessage());
+        $message                          = trim($e->getMessage());
         $this->additionalDetails['trace'] = $e->getTrace();
 
         $previous = [];
-        $e = $e->getPrevious();
+        $e        = $e->getPrevious();
         while ($e) {
             $previous[] = [
-                'code' => (int) $e->getCode(),
+                'code'    => (int) $e->getCode(),
                 'message' => trim($e->getMessage()),
-                'trace' => $e->getTrace(),
+                'trace'   => $e->getTrace(),
             ];
-            $e = $e->getPrevious();
+            $e          = $e->getPrevious();
         }
         if (count($previous)) {
             $this->additionalDetails['exception_stack'] = $previous;
@@ -346,7 +357,7 @@ class ApiProblem
     protected function createStatusFromException()
     {
         /** @var Exception|Throwable $e */
-        $e = $this->detail;
+        $e      = $this->detail;
         $status = $e->getCode();
 
         if ($status) {

--- a/src/ApiProblemResponse.php
+++ b/src/ApiProblemResponse.php
@@ -8,16 +8,20 @@
 
 namespace Laminas\ApiTools\ApiProblem;
 
+use Laminas\Http\Headers;
 use Laminas\Http\Response;
+
+use function json_encode;
+
+use const JSON_PARTIAL_OUTPUT_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
 
 /**
  * Represents an ApiProblem response payload.
  */
 class ApiProblemResponse extends Response
 {
-    /**
-     * @var ApiProblem
-     */
+    /** @var ApiProblem */
     protected $apiProblem;
 
     /**
@@ -27,9 +31,6 @@ class ApiProblemResponse extends Response
      */
     protected $jsonFlags;
 
-    /**
-     * @param ApiProblem $apiProblem
-     */
     public function __construct(ApiProblem $apiProblem)
     {
         $this->apiProblem = $apiProblem;
@@ -65,7 +66,7 @@ class ApiProblemResponse extends Response
      * Proxies to parent class, but then checks if we have an content-type
      * header; if not, sets it, with a value of "application/problem+json".
      *
-     * @return \Laminas\Http\Headers
+     * @return Headers
      */
     public function getHeaders()
     {

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -12,19 +12,13 @@ class DomainException extends \DomainException implements
     ExceptionInterface,
     ProblemExceptionInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $type;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $details = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $title;
 
     /**

--- a/src/Exception/ProblemExceptionInterface.php
+++ b/src/Exception/ProblemExceptionInterface.php
@@ -8,13 +8,15 @@
 
 namespace Laminas\ApiTools\ApiProblem\Exception;
 
+use Traversable;
+
 /**
  * Interface for exceptions that can provide additional API Problem details.
  */
 interface ProblemExceptionInterface
 {
     /**
-     * @return null|array|\Traversable
+     * @return null|array|Traversable
      */
     public function getAdditionalDetails();
 

--- a/src/Factory/ApiProblemListenerFactory.php
+++ b/src/Factory/ApiProblemListenerFactory.php
@@ -14,13 +14,12 @@ use Laminas\ApiTools\ApiProblem\Listener\ApiProblemListener;
 class ApiProblemListenerFactory
 {
     /**
-     * @param ContainerInterface $container
      * @return ApiProblemListener
      */
     public function __invoke(ContainerInterface $container)
     {
         $filters = null;
-        $config = [];
+        $config  = [];
 
         if ($container->has('config')) {
             $config = $container->get('config');

--- a/src/Factory/ApiProblemRendererFactory.php
+++ b/src/Factory/ApiProblemRendererFactory.php
@@ -14,12 +14,11 @@ use Laminas\ApiTools\ApiProblem\View\ApiProblemRenderer;
 class ApiProblemRendererFactory
 {
     /**
-     * @param ContainerInterface $container
      * @return ApiProblemRenderer
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('config');
+        $config            = $container->get('config');
         $displayExceptions = isset($config['view_manager'])
             && isset($config['view_manager']['display_exceptions'])
             && $config['view_manager']['display_exceptions'];

--- a/src/Factory/ApiProblemStrategyFactory.php
+++ b/src/Factory/ApiProblemStrategyFactory.php
@@ -15,7 +15,6 @@ use Laminas\ApiTools\ApiProblem\View\ApiProblemStrategy;
 class ApiProblemStrategyFactory
 {
     /**
-     * @param ContainerInterface $container
      * @return ApiProblemStrategy
      */
     public function __invoke(ContainerInterface $container)

--- a/src/Factory/RenderErrorListenerFactory.php
+++ b/src/Factory/RenderErrorListenerFactory.php
@@ -14,15 +14,15 @@ use Laminas\ApiTools\ApiProblem\Listener\RenderErrorListener;
 class RenderErrorListenerFactory
 {
     /**
-     * @param ContainerInterface $container
      * @return RenderErrorListener
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('config');
+        $config            = $container->get('config');
         $displayExceptions = false;
 
-        if (isset($config['view_manager'])
+        if (
+            isset($config['view_manager'])
             && isset($config['view_manager']['display_exceptions'])
         ) {
             $displayExceptions = (bool) $config['view_manager']['display_exceptions'];

--- a/src/Factory/SendApiProblemResponseListenerFactory.php
+++ b/src/Factory/SendApiProblemResponseListenerFactory.php
@@ -15,12 +15,11 @@ use Laminas\Http\Response as HttpResponse;
 class SendApiProblemResponseListenerFactory
 {
     /**
-     * @param ContainerInterface $container
      * @return SendApiProblemResponseListener
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('config');
+        $config            = $container->get('config');
         $displayExceptions = isset($config['view_manager'])
             && isset($config['view_manager']['display_exceptions'])
             && $config['view_manager']['display_exceptions'];

--- a/src/Listener/RenderErrorListener.php
+++ b/src/Listener/RenderErrorListener.php
@@ -16,6 +16,8 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\View\Exception\ExceptionInterface as ViewExceptionInterface;
 use Throwable;
 
+use function json_encode;
+
 /**
  * RenderErrorListener.
  *
@@ -23,9 +25,7 @@ use Throwable;
  */
 class RenderErrorListener extends AbstractListenerAggregate
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $displayExceptions = false;
 
     /**
@@ -38,7 +38,6 @@ class RenderErrorListener extends AbstractListenerAggregate
 
     /**
      * @param bool $flag
-     *
      * @return RenderErrorListener
      */
     public function setDisplayExceptions($flag)
@@ -55,20 +54,19 @@ class RenderErrorListener extends AbstractListenerAggregate
      * the PhpRenderer, when we have no templates.
      *
      * As such, report as an unacceptable response.
-     *
-     * @param MvcEvent $e
      */
     public function onRenderError(MvcEvent $e)
     {
-        $response = $e->getResponse();
-        $status = 406;
-        $title = 'Not Acceptable';
+        $response    = $e->getResponse();
+        $status      = 406;
+        $title       = 'Not Acceptable';
         $describedBy = 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html';
-        $detail = 'Your request could not be resolved to an acceptable representation.';
-        $details = false;
+        $detail      = 'Your request could not be resolved to an acceptable representation.';
+        $details     = false;
 
         $exception = $e->getParam('exception');
-        if (($exception instanceof Throwable || $exception instanceof Exception)
+        if (
+            ($exception instanceof Throwable || $exception instanceof Exception)
             && ! $exception instanceof ViewExceptionInterface
         ) {
             $code = $exception->getCode();
@@ -77,20 +75,20 @@ class RenderErrorListener extends AbstractListenerAggregate
             } else {
                 $status = 500;
             }
-            $title = 'Unexpected error';
-            $detail = $exception->getMessage();
+            $title   = 'Unexpected error';
+            $detail  = $exception->getMessage();
             $details = [
-                'code' => $exception->getCode(),
+                'code'    => $exception->getCode(),
                 'message' => $exception->getMessage(),
-                'trace' => $exception->getTraceAsString(),
+                'trace'   => $exception->getTraceAsString(),
             ];
         }
 
         $payload = [
-            'status' => $status,
-            'title' => $title,
+            'status'      => $status,
+            'title'       => $title,
             'describedBy' => $describedBy,
-            'detail' => $detail,
+            'detail'      => $detail,
         ];
         if ($details && $this->displayExceptions) {
             $payload['details'] = $details;

--- a/src/Listener/SendApiProblemResponseListener.php
+++ b/src/Listener/SendApiProblemResponseListener.php
@@ -18,19 +18,13 @@ use Laminas\Mvc\ResponseSender\SendResponseEvent;
  */
 class SendApiProblemResponseListener extends HttpResponseSender
 {
-    /**
-     * @var HttpResponse;
-     */
+    /** @var HttpResponse; */
     protected $applicationResponse;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $displayExceptions = false;
 
     /**
-     * @param HttpResponse $response
-     *
      * @return self
      */
     public function setApplicationResponse(HttpResponse $response)
@@ -44,7 +38,6 @@ class SendApiProblemResponseListener extends HttpResponseSender
      * Set the flag determining whether exception stack traces are included.
      *
      * @param bool $flag
-     *
      * @return self
      */
     public function setDisplayExceptions($flag)
@@ -70,8 +63,6 @@ class SendApiProblemResponseListener extends HttpResponseSender
      * Sets the composed ApiProblem's flag for including the stack trace in the
      * detail based on the display exceptions flag, and then sends content.
      *
-     * @param SendResponseEvent $e
-     *
      * @return self
      */
     public function sendContent(SendResponseEvent $e)
@@ -90,8 +81,6 @@ class SendApiProblemResponseListener extends HttpResponseSender
      *
      * If an application response is composed, and is an HTTP response, merges
      * its headers with the ApiProblemResponse headers prior to sending them.
-     *
-     * @param SendResponseEvent $e
      *
      * @return self
      */
@@ -112,8 +101,6 @@ class SendApiProblemResponseListener extends HttpResponseSender
     /**
      * Send ApiProblem response.
      *
-     * @param SendResponseEvent $event
-     *
      * @return self
      */
     public function __invoke(SendResponseEvent $event)
@@ -132,9 +119,6 @@ class SendApiProblemResponseListener extends HttpResponseSender
 
     /**
      * Merge headers set on the application response into the API Problem response.
-     *
-     * @param HttpResponse       $applicationResponse
-     * @param ApiProblemResponse $apiProblemResponse
      */
     protected function mergeHeaders(HttpResponse $applicationResponse, ApiProblemResponse $apiProblemResponse)
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -28,12 +28,10 @@ class Module
      * Listener for bootstrap event.
      *
      * Attaches a render event.
-     *
-     * @param  MvcEvent $e
      */
     public function onBootstrap(MvcEvent $e)
     {
-        $app = $e->getTarget();
+        $app            = $e->getTarget();
         $serviceManager = $app->getServiceManager();
         $eventManager   = $app->getEventManager();
 
@@ -52,16 +50,14 @@ class Module
      * Listener for the render event.
      *
      * Attaches a rendering/response strategy to the View.
-     *
-     * @param  MvcEvent $e
      */
     public function onRender(MvcEvent $e)
     {
-        $app = $e->getTarget();
+        $app      = $e->getTarget();
         $services = $app->getServiceManager();
 
         if ($services->has('View')) {
-            $view = $services->get('View');
+            $view   = $services->get('View');
             $events = $view->getEventManager();
 
             // register at high priority, to "beat" normal json strategy registered

--- a/src/View/ApiProblemModel.php
+++ b/src/View/ApiProblemModel.php
@@ -13,25 +13,16 @@ use Laminas\View\Model\ViewModel;
 
 class ApiProblemModel extends ViewModel
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $captureTo = 'errors';
 
-    /**
-     * @var ApiProblem
-     */
+    /** @var ApiProblem */
     protected $problem;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $terminate = true;
 
-    /**
-     * @param ApiProblem|null $problem
-     */
-    public function __construct(ApiProblem $problem = null)
+    public function __construct(?ApiProblem $problem = null)
     {
         if ($problem instanceof ApiProblem) {
             $this->setApiProblem($problem);
@@ -39,8 +30,6 @@ class ApiProblemModel extends ViewModel
     }
 
     /**
-     * @param ApiProblem $problem
-     *
      * @return ApiProblemModel
      */
     public function setApiProblem(ApiProblem $problem)

--- a/src/View/ApiProblemRenderer.php
+++ b/src/View/ApiProblemRenderer.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\ApiTools\ApiProblem\View;
 
+use Laminas\View\Model\ModelInterface;
 use Laminas\View\Renderer\JsonRenderer;
 
 class ApiProblemRenderer extends JsonRenderer
@@ -23,7 +24,6 @@ class ApiProblemRenderer extends JsonRenderer
      * Set display_exceptions flag.
      *
      * @param bool $flag
-     *
      * @return self
      */
     public function setDisplayExceptions($flag)
@@ -34,9 +34,8 @@ class ApiProblemRenderer extends JsonRenderer
     }
 
     /**
-     * @param string|\Laminas\View\Model\ModelInterface $nameOrModel
+     * @param string|ModelInterface $nameOrModel
      * @param array|null                             $values
-     *
      * @return string
      */
     public function render($nameOrModel, $values = null)

--- a/src/View/ApiProblemStrategy.php
+++ b/src/View/ApiProblemStrategy.php
@@ -12,6 +12,8 @@ use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\View\Strategy\JsonStrategy;
 use Laminas\View\ViewEvent;
 
+use function is_string;
+
 /**
  * Extension of the JSON strategy to handle the ApiProblemModel and provide
  * a Content-Type header appropriate to the response it describes.
@@ -23,9 +25,6 @@ use Laminas\View\ViewEvent;
  */
 class ApiProblemStrategy extends JsonStrategy
 {
-    /**
-     * @param ApiProblemRenderer $renderer
-     */
     public function __construct(ApiProblemRenderer $renderer)
     {
         $this->renderer = $renderer;
@@ -33,8 +32,6 @@ class ApiProblemStrategy extends JsonStrategy
 
     /**
      * Detect if we should use the ApiProblemRenderer based on model type.
-     *
-     * @param ViewEvent $e
      *
      * @return null|ApiProblemRenderer
      */
@@ -56,8 +53,6 @@ class ApiProblemStrategy extends JsonStrategy
      *
      * Injects the response with the rendered content, and sets the content
      * type based on the detection that occurred during renderer selection.
-     *
-     * @param ViewEvent $e
      */
     public function injectResponse(ViewEvent $e)
     {
@@ -89,8 +84,6 @@ class ApiProblemStrategy extends JsonStrategy
      * Retrieve the HTTP status from an ApiProblem object.
      *
      * Ensures that the status falls within the acceptable range (100 - 599).
-     *
-     * @param ApiProblem $problem
      *
      * @return int
      */

--- a/test/ApiProblemResponseTest.php
+++ b/test/ApiProblemResponseTest.php
@@ -10,14 +10,20 @@ namespace LaminasTest\ApiTools\ApiProblem;
 
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Laminas\Http\Header\ContentType;
+use Laminas\Http\Response;
 use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function json_decode;
+use function strtolower;
 
 class ApiProblemResponseTest extends TestCase
 {
     public function testApiProblemResponseIsAnHttpResponse()
     {
         $response = new ApiProblemResponse(new ApiProblem(400, 'Random error'));
-        $this->assertInstanceOf('Laminas\Http\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 
     /**
@@ -35,13 +41,13 @@ class ApiProblemResponseTest extends TestCase
     public function testApiProblemResponseBodyIsSerializedApiProblem()
     {
         $additional = [
-            'foo' => fopen('php://memory', 'r')
+            'foo' => fopen('php://memory', 'r'),
         ];
 
         $expected = [
-            'foo' => null,
-            'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
-            'title' => 'Bad Request',
+            'foo'    => null,
+            'type'   => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+            'title'  => 'Bad Request',
             'status' => 400,
             'detail' => 'Random error',
         ];
@@ -60,7 +66,7 @@ class ApiProblemResponseTest extends TestCase
         $headers  = $response->getHeaders();
         $this->assertTrue($headers->has('content-type'));
         $header = $headers->get('content-type');
-        $this->assertInstanceOf('Laminas\Http\Header\ContentType', $header);
+        $this->assertInstanceOf(ContentType::class, $header);
         $this->assertEquals(ApiProblem::CONTENT_TYPE, $header->getFieldValue());
     }
 

--- a/test/ApiProblemResponseTest.php
+++ b/test/ApiProblemResponseTest.php
@@ -27,7 +27,7 @@ class ApiProblemResponseTest extends TestCase
     {
         $response = new ApiProblemResponse(new ApiProblem(400, 'Random error'));
         $this->assertEquals(400, $response->getStatusCode());
-        $this->assertInternalType('string', $response->getReasonPhrase());
+        $this->assertIsString($response->getReasonPhrase());
         $this->assertNotEmpty($response->getReasonPhrase());
         $this->assertEquals('bad request', strtolower($response->getReasonPhrase()));
     }
@@ -77,6 +77,6 @@ class ApiProblemResponseTest extends TestCase
     public function testOverridesReasonPhraseIfStatusCodeIsUnknown()
     {
         $response = new ApiProblemResponse(new ApiProblem(7, 'Random error'));
-        $this->assertContains('Internal Server Error', $response->getReasonPhrase());
+        $this->assertStringContainsString('Internal Server Error', $response->getReasonPhrase());
     }
 }

--- a/test/ApiProblemTest.php
+++ b/test/ApiProblemTest.php
@@ -91,7 +91,7 @@ class ApiProblemTest extends TestCase
         $apiProblem->setDetailIncludesStackTrace(true);
         $payload = $apiProblem->toArray();
         $this->assertArrayHasKey('trace', $payload);
-        $this->assertInternalType('array', $payload['trace']);
+        $this->assertIsArray($payload['trace']);
         $this->assertEquals($exception->getTrace(), $payload['trace']);
     }
 
@@ -104,7 +104,7 @@ class ApiProblemTest extends TestCase
         $apiProblem->setDetailIncludesStackTrace(true);
         $payload = $apiProblem->toArray();
         $this->assertArrayHasKey('exception_stack', $payload);
-        $this->assertInternalType('array', $payload['exception_stack']);
+        $this->assertIsArray($payload['exception_stack']);
         $expected = [
             [
                 'code' => $exceptionChild->getCode(),

--- a/test/ApiProblemTest.php
+++ b/test/ApiProblemTest.php
@@ -12,9 +12,11 @@ use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
+use TypeError;
 
 class ApiProblemTest extends TestCase
 {
+    /** @return array */
     public function statusCodes()
     {
         return [
@@ -32,11 +34,12 @@ class ApiProblemTest extends TestCase
 
     /**
      * @dataProvider statusCodes
+     * @param int $status
      */
     public function testStatusIsUsedVerbatim($status)
     {
         $apiProblem = new ApiProblem($status, 'foo');
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('status', $payload);
         $this->assertEquals($status, $payload['status']);
     }
@@ -46,9 +49,9 @@ class ApiProblemTest extends TestCase
      */
     public function testErrorAsDetails()
     {
-        $error = new \TypeError('error message', 705);
+        $error      = new TypeError('error message', 705);
         $apiProblem = new ApiProblem(500, $error);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
 
         $this->assertArrayHasKey('title', $payload);
         $this->assertEquals('TypeError', $payload['title']);
@@ -60,9 +63,9 @@ class ApiProblemTest extends TestCase
 
     public function testExceptionCodeIsUsedForStatus()
     {
-        $exception = new \Exception('exception message', 401);
+        $exception  = new \Exception('exception message', 401);
         $apiProblem = new ApiProblem('500', $exception);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('status', $payload);
         $this->assertEquals($exception->getCode(), $payload['status']);
     }
@@ -70,23 +73,23 @@ class ApiProblemTest extends TestCase
     public function testDetailStringIsUsedVerbatim()
     {
         $apiProblem = new ApiProblem('500', 'foo');
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('detail', $payload);
         $this->assertEquals('foo', $payload['detail']);
     }
 
     public function testExceptionMessageIsUsedForDetail()
     {
-        $exception = new \Exception('exception message');
+        $exception  = new \Exception('exception message');
         $apiProblem = new ApiProblem('500', $exception);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('detail', $payload);
         $this->assertEquals($exception->getMessage(), $payload['detail']);
     }
 
     public function testExceptionsCanTriggerInclusionOfStackTraceInDetails()
     {
-        $exception = new \Exception('exception message');
+        $exception  = new \Exception('exception message');
         $apiProblem = new ApiProblem('500', $exception);
         $apiProblem->setDetailIncludesStackTrace(true);
         $payload = $apiProblem->toArray();
@@ -97,7 +100,7 @@ class ApiProblemTest extends TestCase
 
     public function testExceptionsCanTriggerInclusionOfNestedExceptions()
     {
-        $exceptionChild = new \Exception('child exception');
+        $exceptionChild  = new \Exception('child exception');
         $exceptionParent = new \Exception('parent exception', null, $exceptionChild);
 
         $apiProblem = new ApiProblem('500', $exceptionParent);
@@ -107,9 +110,9 @@ class ApiProblemTest extends TestCase
         $this->assertIsArray($payload['exception_stack']);
         $expected = [
             [
-                'code' => $exceptionChild->getCode(),
+                'code'    => $exceptionChild->getCode(),
                 'message' => $exceptionChild->getMessage(),
-                'trace' => $exceptionChild->getTrace(),
+                'trace'   => $exceptionChild->getTrace(),
             ],
         ];
         $this->assertEquals($expected, $payload['exception_stack']);
@@ -118,11 +121,12 @@ class ApiProblemTest extends TestCase
     public function testTypeUrlIsUsedVerbatim()
     {
         $apiProblem = new ApiProblem('500', 'foo', 'http://status.dev:8080/details.md');
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('type', $payload);
         $this->assertEquals('http://status.dev:8080/details.md', $payload['type']);
     }
 
+    /** @return array */
     public function knownStatusCodes()
     {
         return [
@@ -135,12 +139,13 @@ class ApiProblemTest extends TestCase
 
     /**
      * @dataProvider knownStatusCodes
+     * @param int $status
      */
     public function testKnownStatusResultsInKnownTitle($status)
     {
         $apiProblem = new ApiProblem($status, 'foo');
-        $r = new ReflectionObject($apiProblem);
-        $p = $r->getProperty('problemStatusTitles');
+        $r          = new ReflectionObject($apiProblem);
+        $p          = $r->getProperty('problemStatusTitles');
         $p->setAccessible(true);
         $titles = $p->getValue($apiProblem);
 
@@ -152,7 +157,7 @@ class ApiProblemTest extends TestCase
     public function testUnknownStatusResultsInUnknownTitle()
     {
         $apiProblem = new ApiProblem(420, 'foo');
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('title', $payload);
         $this->assertEquals('Unknown', $payload['title']);
     }
@@ -160,7 +165,7 @@ class ApiProblemTest extends TestCase
     public function testProvidedTitleIsUsedVerbatim()
     {
         $apiProblem = new ApiProblem('500', 'foo', 'http://status.dev:8080/details.md', 'some title');
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('title', $payload);
         $this->assertEquals('some title', $payload['title']);
     }
@@ -186,7 +191,7 @@ class ApiProblemTest extends TestCase
             'Invalid entity',
             ['foo' => 'bar']
         );
-        $array = $problem->toArray();
+        $array   = $problem->toArray();
         $this->assertArrayHasKey('foo', $array);
         $this->assertEquals('bar', $array['foo']);
     }
@@ -200,7 +205,7 @@ class ApiProblemTest extends TestCase
             'Invalid entity',
             ['title' => 'SHOULD NOT GET THIS']
         );
-        $array = $problem->toArray();
+        $array   = $problem->toArray();
         $this->assertArrayHasKey('title', $array);
         $this->assertEquals('Invalid entity', $array['title']);
     }
@@ -210,7 +215,7 @@ class ApiProblemTest extends TestCase
         $exception = new Exception\DomainException('exception message', 401);
         $exception->setTitle('problem title');
         $apiProblem = new ApiProblem('401', $exception);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('title', $payload);
         $this->assertEquals($exception->getTitle(), $payload['title']);
     }
@@ -220,7 +225,7 @@ class ApiProblemTest extends TestCase
         $exception = new Exception\DomainException('exception message', 401);
         $exception->setType('http://example.com/api/help/401');
         $apiProblem = new ApiProblem('401', $exception);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('type', $payload);
         $this->assertEquals($exception->getType(), $payload['type']);
     }
@@ -230,18 +235,19 @@ class ApiProblemTest extends TestCase
         $exception = new Exception\DomainException('exception message', 401);
         $exception->setAdditionalDetails(['foo' => 'bar']);
         $apiProblem = new ApiProblem('401', $exception);
-        $payload = $apiProblem->toArray();
+        $payload    = $apiProblem->toArray();
         $this->assertArrayHasKey('foo', $payload);
         $this->assertEquals('bar', $payload['foo']);
     }
 
+    /** @return array */
     public function invalidStatusCodes()
     {
         return [
-            '-1' => [-1],
-            '0' => [0],
-            '7' => [7],  // reported
-            '14' => [14], // observed
+            '-1'  => [-1],
+            '0'   => [0],
+            '7'   => [7], // reported
+            '14'  => [14], // observed
             '600' => [600],
         ];
     }
@@ -249,10 +255,11 @@ class ApiProblemTest extends TestCase
     /**
      * @dataProvider invalidStatusCodes
      * @group api-tools-118
+     * @param int $code
      */
     public function testInvalidHttpStatusCodesAreCastTo500($code)
     {
-        $e = new \Exception('Testing', $code);
+        $e       = new \Exception('Testing', $code);
         $problem = new ApiProblem($code, $e);
         $this->assertEquals(500, $problem->status);
     }

--- a/test/Listener/ApiProblemListenerTest.php
+++ b/test/Listener/ApiProblemListenerTest.php
@@ -15,10 +15,13 @@ use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\RequestInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ApiProblemListenerTest extends TestCase
 {
-    protected function setUp()
+    use ProphecyTrait;
+
+    protected function setUp(): void
     {
         $this->event = new MvcEvent();
         $this->event->setError('this is an error event');

--- a/test/Listener/ApiProblemListenerTest.php
+++ b/test/Listener/ApiProblemListenerTest.php
@@ -8,6 +8,8 @@
 
 namespace LaminasTest\ApiTools\ApiProblem\Listener;
 
+use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use Laminas\ApiTools\ApiProblem\Exception\DomainException;
 use Laminas\ApiTools\ApiProblem\Listener\ApiProblemListener;
 use Laminas\Http\Request;
@@ -16,6 +18,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\RequestInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use TypeError;
 
 class ApiProblemListenerTest extends TestCase
 {
@@ -48,11 +51,11 @@ class ApiProblemListenerTest extends TestCase
         $return = $this->listener->onDispatchError($event);
 
         $this->assertTrue($event->propagationIsStopped());
-        $this->assertInstanceOf('Laminas\ApiTools\ApiProblem\ApiProblemResponse', $return);
+        $this->assertInstanceOf(ApiProblemResponse::class, $return);
         $response = $event->getResponse();
         $this->assertSame($return, $response);
         $problem = $response->getApiProblem();
-        $this->assertInstanceOf('Laminas\ApiTools\ApiProblem\ApiProblem', $problem);
+        $this->assertInstanceOf(ApiProblem::class, $problem);
         $this->assertEquals(400, $problem->status);
         $this->assertSame($event->getParam('exception'), $problem->detail);
     }
@@ -67,16 +70,16 @@ class ApiProblemListenerTest extends TestCase
 
         $event = new MvcEvent();
         $event->setError(Application::ERROR_EXCEPTION);
-        $event->setParam('exception', new \TypeError('triggering throwable', 400));
+        $event->setParam('exception', new TypeError('triggering throwable', 400));
         $event->setRequest($request);
         $return = $this->listener->onDispatchError($event);
 
         $this->assertTrue($event->propagationIsStopped());
-        $this->assertInstanceOf('Laminas\ApiTools\ApiProblem\ApiProblemResponse', $return);
+        $this->assertInstanceOf(ApiProblemResponse::class, $return);
         $response = $event->getResponse();
         $this->assertSame($return, $response);
         $problem = $response->getApiProblem();
-        $this->assertInstanceOf('Laminas\ApiTools\ApiProblem\ApiProblem', $problem);
+        $this->assertInstanceOf(ApiProblem::class, $problem);
         $this->assertEquals(400, $problem->status);
         $this->assertSame($event->getParam('exception'), $problem->detail);
     }

--- a/test/Listener/RenderErrorListenerTest.php
+++ b/test/Listener/RenderErrorListenerTest.php
@@ -18,11 +18,11 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use TypeError;
 
+use function json_decode;
+
 class RenderErrorListenerTest extends TestCase
 {
-    /**
-     * @var RenderErrorListener
-     */
+    /** @var RenderErrorListener */
     protected $listener;
 
     protected function setUp(): void
@@ -33,7 +33,7 @@ class RenderErrorListenerTest extends TestCase
     public function testOnRenderErrorCreatesAnApiProblemResponse()
     {
         $response = new Response();
-        $request = new Request();
+        $request  = new Request();
         $request->getHeaders()->addHeaderLine('Accept', 'application/json');
 
         $event = new MvcEvent();
@@ -64,7 +64,7 @@ class RenderErrorListenerTest extends TestCase
     public function testOnRenderErrorCreatesAnApiProblemResponseFromException()
     {
         $response = new Response();
-        $request = new Request();
+        $request  = new Request();
         $request->getHeaders()->addHeaderLine('Accept', 'application/json');
 
         $event = new MvcEvent();
@@ -110,7 +110,7 @@ class RenderErrorListenerTest extends TestCase
     public function testOnRenderErrorCreatesAnApiProblemResponseFromThrowable()
     {
         $response = new Response();
-        $request = new Request();
+        $request  = new Request();
         $request->getHeaders()->addHeaderLine('Accept', 'application/json');
 
         $event = new MvcEvent();

--- a/test/Listener/RenderErrorListenerTest.php
+++ b/test/Listener/RenderErrorListenerTest.php
@@ -25,7 +25,7 @@ class RenderErrorListenerTest extends TestCase
      */
     protected $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new RenderErrorListener();
     }
@@ -57,8 +57,8 @@ class RenderErrorListenerTest extends TestCase
 
         $this->assertEquals(406, $content['status']);
         $this->assertEquals('Not Acceptable', $content['title']);
-        $this->assertContains('www.w3.org', $content['describedBy']);
-        $this->assertContains('accept', $content['detail']);
+        $this->assertStringContainsString('www.w3.org', $content['describedBy']);
+        $this->assertStringContainsString('accept', $content['detail']);
     }
 
     public function testOnRenderErrorCreatesAnApiProblemResponseFromException()
@@ -92,10 +92,10 @@ class RenderErrorListenerTest extends TestCase
 
         $this->assertEquals(400, $content['status']);
         $this->assertEquals('Unexpected error', $content['title']);
-        $this->assertContains('www.w3.org', $content['describedBy']);
+        $this->assertStringContainsString('www.w3.org', $content['describedBy']);
         $this->assertEquals('exception', $content['detail']);
 
-        $this->assertInternalType('array', $content['details']);
+        $this->assertIsArray($content['details']);
         $details = $content['details'];
         $this->assertArrayHasKey('code', $details);
         $this->assertArrayHasKey('message', $details);
@@ -138,10 +138,10 @@ class RenderErrorListenerTest extends TestCase
 
         $this->assertEquals(400, $content['status']);
         $this->assertEquals('Unexpected error', $content['title']);
-        $this->assertContains('www.w3.org', $content['describedBy']);
+        $this->assertStringContainsString('www.w3.org', $content['describedBy']);
         $this->assertEquals('throwable', $content['detail']);
 
-        $this->assertInternalType('array', $content['details']);
+        $this->assertIsArray($content['details']);
         $details = $content['details'];
         $this->assertArrayHasKey('code', $details);
         $this->assertArrayHasKey('message', $details);

--- a/test/Listener/SendApiProblemResponseListenerTest.php
+++ b/test/Listener/SendApiProblemResponseListenerTest.php
@@ -13,24 +13,30 @@ use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use Laminas\ApiTools\ApiProblem\Exception\DomainException;
 use Laminas\ApiTools\ApiProblem\Listener\SendApiProblemResponseListener;
 use Laminas\Http\Response as HttpResponse;
+use Laminas\Mvc\ResponseSender\ResponseSenderInterface;
 use Laminas\Mvc\ResponseSender\SendResponseEvent;
 use PHPUnit\Framework\TestCase;
+
+use function count;
+use function json_decode;
+use function ob_get_clean;
+use function ob_start;
 
 class SendApiProblemResponseListenerTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->exception = new DomainException('Random error', 400);
+        $this->exception  = new DomainException('Random error', 400);
         $this->apiProblem = new ApiProblem(400, $this->exception);
-        $this->response = new ApiProblemResponse($this->apiProblem);
-        $this->event = new SendResponseEvent();
+        $this->response   = new ApiProblemResponse($this->apiProblem);
+        $this->event      = new SendResponseEvent();
         $this->event->setResponse($this->response);
         $this->listener = new SendApiProblemResponseListener();
     }
 
     public function testListenerImplementsResponseSenderInterface()
     {
-        $this->assertInstanceOf('Laminas\Mvc\ResponseSender\ResponseSenderInterface', $this->listener);
+        $this->assertInstanceOf(ResponseSenderInterface::class, $this->listener);
     }
 
     public function testDisplayExceptionsFlagIsFalseByDefault()

--- a/test/Listener/SendApiProblemResponseListenerTest.php
+++ b/test/Listener/SendApiProblemResponseListenerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class SendApiProblemResponseListenerTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = new DomainException('Random error', 400);
         $this->apiProblem = new ApiProblem(400, $this->exception);
@@ -55,10 +55,10 @@ class SendApiProblemResponseListenerTest extends TestCase
         ob_start();
         $this->listener->sendContent($this->event);
         $contents = ob_get_clean();
-        $this->assertInternalType('string', $contents);
+        $this->assertIsString($contents);
         $data = json_decode($contents, true);
-        $this->assertNotContains("\n", $data['detail']);
-        $this->assertNotContains($this->exception->getTraceAsString(), $data['detail']);
+        $this->assertStringNotContainsString("\n", $data['detail']);
+        $this->assertStringNotContainsString($this->exception->getTraceAsString(), $data['detail']);
     }
 
     public function testEnablingDisplayExceptionFlagRendersExceptionStackTrace()
@@ -67,10 +67,10 @@ class SendApiProblemResponseListenerTest extends TestCase
         ob_start();
         $this->listener->sendContent($this->event);
         $contents = ob_get_clean();
-        $this->assertInternalType('string', $contents);
+        $this->assertIsString($contents);
         $data = json_decode($contents, true);
         $this->assertArrayHasKey('trace', $data);
-        $this->assertInternalType('array', $data['trace']);
+        $this->assertIsArray($data['trace']);
         $this->assertGreaterThanOrEqual(1, count($data['trace']));
     }
 
@@ -80,7 +80,7 @@ class SendApiProblemResponseListenerTest extends TestCase
         ob_start();
         $this->listener->sendContent($this->event);
         $contents = ob_get_clean();
-        $this->assertInternalType('string', $contents);
+        $this->assertIsString($contents);
         $this->assertEmpty($contents);
     }
 

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -16,11 +16,13 @@ use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Mvc\SendResponseListener;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 class ModuleTest extends TestCase
 {
+    /** @return EventManager */
     public function marshalEventManager()
     {
         $r = new ReflectionClass(EventManager::class);
@@ -36,14 +38,14 @@ class ModuleTest extends TestCase
     {
         $module = new Module();
 
-        $application = $this->getMockBuilder(Application::class)
+        $application    = $this->getMockBuilder(Application::class)
             ->disableOriginalConstructor()
             ->getMock();
         $serviceLocator = $this->getMockForAbstractClass(ServiceLocatorInterface::class);
         $serviceLocator->method('get')->will($this->returnCallback([$this, 'serviceLocator']));
 
         $eventManager = $this->marshalEventManager();
-        $event = $this->getMockBuilder(MvcEvent::class)->getMock();
+        $event        = $this->getMockBuilder(MvcEvent::class)->getMock();
 
         $application->method('getServiceManager')->willReturn($serviceLocator);
         $application->method('getEventManager')->willReturn($eventManager);
@@ -52,22 +54,23 @@ class ModuleTest extends TestCase
         $module->onBootstrap($event);
     }
 
+    /**
+     * @param string $service
+     * @return ApiProblemListener|SendApiProblemResponseListener|SendResponseListener|MockObject
+     */
     public function serviceLocator($service)
     {
         switch ($service) {
-            case 'Laminas\ApiTools\ApiProblem\Listener\ApiProblemListener':
+            case ApiProblemListener::class:
                 return new ApiProblemListener();
-                break;
             case 'SendResponseListener':
                 $listener = $this->getMockBuilder(SendResponseListener::class)->getMock();
                 $listener->method('getEventManager')->willReturn(new EventManager());
 
                 return $listener;
-                break;
             case SendApiProblemResponseListener::class:
                 return new SendApiProblemResponseListener();
             default:
-                //
         }
     }
 }

--- a/test/View/ApiProblemRendererTest.php
+++ b/test/View/ApiProblemRendererTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ApiProblemRendererTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ApiProblemRenderer();
     }
@@ -45,7 +45,7 @@ class ApiProblemRendererTest extends TestCase
         $test = $this->renderer->render($model);
         $test = json_decode($test, true);
         $this->assertArrayHasKey('trace', $test);
-        $this->assertInternalType('array', $test['trace']);
+        $this->assertIsArray($test['trace']);
         $this->assertGreaterThanOrEqual(1, count($test['trace']));
     }
 }

--- a/test/View/ApiProblemRendererTest.php
+++ b/test/View/ApiProblemRendererTest.php
@@ -8,10 +8,14 @@
 
 namespace LaminasTest\ApiTools\ApiProblem\View;
 
+use Exception;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\View\ApiProblemModel;
 use Laminas\ApiTools\ApiProblem\View\ApiProblemRenderer;
 use PHPUnit\Framework\TestCase;
+
+use function count;
+use function json_decode;
 
 class ApiProblemRendererTest extends TestCase
 {
@@ -23,13 +27,13 @@ class ApiProblemRendererTest extends TestCase
     public function testRendersApiProblemCorrectly()
     {
         $apiProblem = new ApiProblem(401, 'login error', 'http://status.dev/errors.md', 'Unauthorized');
-        $model = new ApiProblemModel();
+        $model      = new ApiProblemModel();
         $model->setApiProblem($apiProblem);
-        $test = $this->renderer->render($model);
+        $test     = $this->renderer->render($model);
         $expected = [
             'status' => 401,
-            'type' => 'http://status.dev/errors.md',
-            'title' => 'Unauthorized',
+            'type'   => 'http://status.dev/errors.md',
+            'title'  => 'Unauthorized',
             'detail' => 'login error',
         ];
         $this->assertEquals($expected, json_decode($test, true));
@@ -37,9 +41,9 @@ class ApiProblemRendererTest extends TestCase
 
     public function testCanHintToApiProblemToRenderStackTrace()
     {
-        $exception = new \Exception('exception message', 500);
+        $exception  = new Exception('exception message', 500);
         $apiProblem = new ApiProblem(500, $exception);
-        $model = new ApiProblemModel();
+        $model      = new ApiProblemModel();
         $model->setApiProblem($apiProblem);
         $this->renderer->setDisplayExceptions(true);
         $test = $this->renderer->render($model);

--- a/test/View/ApiProblemStrategyTest.php
+++ b/test/View/ApiProblemStrategyTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 class ApiProblemStrategyTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->response = new Response();
         $this->event = new ViewEvent();

--- a/test/View/ApiProblemStrategyTest.php
+++ b/test/View/ApiProblemStrategyTest.php
@@ -14,6 +14,7 @@ use Laminas\ApiTools\ApiProblem\View\ApiProblemRenderer;
 use Laminas\ApiTools\ApiProblem\View\ApiProblemStrategy;
 use Laminas\Http\Response;
 use Laminas\View\Model\JsonModel;
+use Laminas\View\Model\ModelInterface as Model;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\ViewEvent;
 use PHPUnit\Framework\TestCase;
@@ -23,24 +24,26 @@ class ApiProblemStrategyTest extends TestCase
     protected function setUp(): void
     {
         $this->response = new Response();
-        $this->event = new ViewEvent();
+        $this->event    = new ViewEvent();
         $this->event->setResponse($this->response);
 
         $this->renderer = new ApiProblemRenderer();
         $this->strategy = new ApiProblemStrategy($this->renderer);
     }
 
+    /** @return array */
     public function invalidViewModels()
     {
         return [
-            'null' => [null],
+            'null'    => [null],
             'generic' => [new ViewModel()],
-            'json' => [new JsonModel()],
+            'json'    => [new JsonModel()],
         ];
     }
 
     /**
      * @dataProvider invalidViewModels
+     * @param null|Model $model
      */
     public function testSelectRendererReturnsNullIfModelIsNotAnApiProblemModel($model)
     {
@@ -69,7 +72,7 @@ class ApiProblemStrategyTest extends TestCase
     public function testInjectResponseSetsContentTypeHeaderToApiProblemForApiProblemModel()
     {
         $problem = new ApiProblem(500, 'whatever', 'foo', 'bar');
-        $model = new ApiProblemModel($problem);
+        $model   = new ApiProblemModel($problem);
         $this->event->setModel($model);
         $this->event->setRenderer($this->renderer);
         $this->event->setResult('{"foo":"bar"}');
@@ -80,6 +83,7 @@ class ApiProblemStrategyTest extends TestCase
         $this->assertEquals(ApiProblem::CONTENT_TYPE, $header->getFieldValue());
     }
 
+    /** @return array */
     public function invalidStatusCodes()
     {
         return [
@@ -93,11 +97,12 @@ class ApiProblemStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidStatusCodes
+     * @param int $status
      */
     public function testUsesStatusCode500ForAnyStatusCodesAbove599OrBelow100($status)
     {
         $problem = new ApiProblem($status, 'whatever');
-        $model = new ApiProblemModel($problem);
+        $model   = new ApiProblemModel($problem);
         $this->event->setModel($model);
         $this->event->setRenderer($this->renderer);
         $this->event->setResult('{"foo":"bar"}');


### PR DESCRIPTION

Q | A
-- | --
Documentation | no
Bugfix | no
BC Break | no
New Feature | yes
RFC | no
QA | yes

### Description
Fixes issue #12 - PHP 8.0 support.

I am planning to add PHP 8 support for the following packages:

- laminas-api-tools/api-tools-provider
- laminas-api-tools/api-tools-versioning
- laminas-api-tools/api-tools-api-problem
- laminas-api-tools/api-tools-content-negotiation
- laminas-api-tools/api-tools-content-validation
- laminas-api-tools/api-tools-oauth2
- laminas-api-tools/api-tools-mvc-auth
- laminas-api-tools/api-tools-rest
- laminas-api-tools/api-tools-rpc
- laminas-api-tools/api-tools
- laminas-api-tools/api-tools-admin
